### PR TITLE
Flags by OS & constexpr fixes and missing libraries

### DIFF
--- a/FFT3DFilter.cpp
+++ b/FFT3DFilter.cpp
@@ -83,7 +83,8 @@
 
 #include <cstring>
 #include <algorithm>
-
+#include <cmath>
+#include <stdlib.h>
 #include "FFT3DFilter.h"
 #include "info.h"
 
@@ -197,8 +198,8 @@ static void SigmasToPattern( float sigma, float sigma2, float sigma3, float sigm
 {
     /* it is not fast, but called only in constructor */
     float sigmacur;
-    constexpr float ft2 = sqrt( 0.5f ) / 2; /* frequency for sigma2 */
-    constexpr float ft3 = sqrt( 0.5f ) / 4; /* frequency for sigma3 */
+    const float ft2 = sqrt( 0.5f ) / 2; /* frequency for sigma2 */
+    const float ft3 = sqrt( 0.5f ) / 4; /* frequency for sigma3 */
     for( int h = 0; h < bh; h++ )
     {
         for( int w = 0; w < outwidth; w++ )

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,6 +31,7 @@ install: all
 ifneq ($(IMPLIB),)
 	install -m 644 $(IMPLIB) $(DESTDIR)$(libdir)
 else
+	$(RM) $(libdir)/lib$(BASENAME).*.*
 	install -m 644 $(SONAME) $(DESTDIR)$(libdir)/$(SONAME)
 	$(if $(SONAME), ln -f -s $(libdir)/$(SONAME) $(DESTDIR)$(vsplugindir)/$(SONAME_LN))
 endif

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -31,7 +31,7 @@ install: all
 ifneq ($(IMPLIB),)
 	install -m 644 $(IMPLIB) $(DESTDIR)$(libdir)
 else
-	$(RM) $(libdir)/lib$(BASENAME).*.*
+	$(RM) $(libdir)/lib$(BASENAME).*
 	install -m 644 $(SONAME) $(DESTDIR)$(libdir)/$(SONAME)
 	$(if $(SONAME), ln -f -s $(libdir)/$(SONAME) $(DESTDIR)$(vsplugindir)/$(SONAME_LN))
 endif

--- a/configure
+++ b/configure
@@ -163,19 +163,20 @@ else
 fi
 case "$TARGET_OS" in
     *mingw*|*cygwin*)
-        SYS="WIN32"
         SOSUFFIX="dll"
         SONAME="$BASENAME.$SOSUFFIX"
         SOFLAGS="-Wl,--enable-auto-image-base -Wl,--export-all-symbols"
         ;;
     *darwin*)
-        SYS="MACOSX"
         SOSUFFIX="dylib"
         SONAME="lib$BASENAME.$REV.$SOSUFFIX"
         SONAME_LN="lib$BASENAME.$SOSUFFIX"
         SOFLAGS="-dynamiclib -Wl,-single_module -Wl,-read_only_relocs,suppress -install_name ${DESTDIR}${libdir}/${SONAME}"
+        CXXFLAGS="$CXXFLAGS -fPIC"
+        LDFLAGS="-fPIC $LDFLAGS"
+        DEPLIBS="libfftw3f_threads $DEPLIBS libm"
         ;;
-    *)
+	*linux*)
         SOSUFFIX="so"
         SONAME="lib$BASENAME.$SOSUFFIX.$REV"
         SONAME_LN="lib$BASENAME.$SOSUFFIX"
@@ -183,7 +184,9 @@ case "$TARGET_OS" in
         CXXFLAGS="$CXXFLAGS -fPIC"
         LDFLAGS="-fPIC $LDFLAGS"
         DEPLIBS="libfftw3f_threads $DEPLIBS libm"
-        ;;
+		;;
+	*)
+		error_exit "target is unsupported system"
 esac
 
 # -- add extra --------------------------------------------------------------------------------

--- a/fft3dfilter_c.cpp
+++ b/fft3dfilter_c.cpp
@@ -22,7 +22,7 @@
  *****************************************************************************/
 
 #include <algorithm>
-
+#include <cmath>
 #include <fftw3.h>
 
 // since v1.7 we use outpitch instead of outwidth


### PR DESCRIPTION
Was having issues compiling in OSX and noticed that the flag changes for darwin were not sticking, instead it was using the flag changes that came after.  Also ran across errors with sqrt being used in an constexpr, which would not compile.  Additionally, cmath and stdlib needed to be defined.
